### PR TITLE
Fixing swap() calls, multi-file warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ $RECYCLE.BIN/
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -41,3 +42,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# IDE Directories
+.idea

--- a/PDQ_ILI9340/PDQ_ILI9340.h
+++ b/PDQ_ILI9340/PDQ_ILI9340.h
@@ -197,7 +197,7 @@ class PDQ_ILI9340 : public PDQ_GFX<PDQ_ILI9340>
 	static inline void spi_begin() __attribute__((always_inline))
 	{
 #if ILI9340_SAVE_SPCR && defined(AVR_HARDWARE_SPI)
-		swap(save_SPCR, SPCR);	// swap initial/current SPCR settings
+		swapValue(save_SPCR, SPCR);	// swap initial/current SPCR settings
 #endif
 		FastPin<ILI9340_CS_PIN>::lo();		// CS <= LOW (selected)
 	}
@@ -208,7 +208,7 @@ class PDQ_ILI9340 : public PDQ_GFX<PDQ_ILI9340>
 	{
 		FastPin<ILI9340_CS_PIN>::hi();		// CS <= HIGH (deselected)
 #if ILI9340_SAVE_SPCR && defined(AVR_HARDWARE_SPI)
-		swap(SPCR, save_SPCR);	// swap current/initial SPCR settings
+		swapValue(SPCR, save_SPCR);	// swap current/initial SPCR settings
 #endif
 	}
 

--- a/PDQ_ST7735/PDQ_ST7735.h
+++ b/PDQ_ST7735/PDQ_ST7735.h
@@ -192,7 +192,7 @@ class PDQ_ST7735 : public PDQ_GFX<PDQ_ST7735>
 	static inline void spi_begin() __attribute__((always_inline))
 	{
 #if ST7735_SAVE_SPCR
-		swap(save_SPCR, SPCR);	// swap initial/current SPCR settings
+		swapValue(save_SPCR, SPCR);	// swap initial/current SPCR settings
 #endif
 		FastPin<ST7735_CS_PIN>::lo();		// CS <= LOW (selected)
 	}
@@ -203,7 +203,7 @@ class PDQ_ST7735 : public PDQ_GFX<PDQ_ST7735>
 	{
 		FastPin<ST7735_CS_PIN>::hi();		// CS <= HIGH (deselected)
 #if ST7735_SAVE_SPCR
-		swap(SPCR, save_SPCR);	// swap current/initial SPCR settings
+		swapValue(SPCR, save_SPCR);	// swap current/initial SPCR settings
 #endif
 	}
 
@@ -851,14 +851,14 @@ void PDQ_ST7735::drawLine(int x0, int y0, int x1, int y1, uint16_t color)
 	int8_t steep = abs(y1 - y0) > abs(x1 - x0);
 	if (steep)
 	{
-		swap(x0, y0);
-		swap(x1, y1);
+		swapValue(x0, y0);
+		swapValue(x1, y1);
 	}
 
 	if (x0 > x1)
 	{
-		swap(x0, x1);
-		swap(y0, y1);
+		swapValue(x0, x1);
+		swapValue(y0, y1);
 	}
 
 	if (x1 < 0)

--- a/PDQ_ST7781/PDQ_ST7781.h
+++ b/PDQ_ST7781/PDQ_ST7781.h
@@ -655,14 +655,14 @@ void PDQ_ST7781::drawLine(int x0, int y0, int x1, int y1, uint16_t color)
 	int8_t steep = abs(y1 - y0) > abs(x1 - x0);
 	if (steep)
 	{
-		swap(x0, y0);
-		swap(x1, y1);
+		swapValue(x0, y0);
+		swapValue(x1, y1);
 	}
 
 	if (x0 > x1)
 	{
-		swap(x0, x1);
-		swap(y0, y1);
+		swapValue(x0, x1);
+		swapValue(y0, y1);
 	}
 
 	if (x1 < 0)

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ New features in latest commit ("v1.0.0" 2015-05-30) include:
  
 Suggestions, issues, bugs and comments welcome.  Via https://hackaday.io/Xark or visit #Arduino channel on Freenode.net IRC.
 I have also posted a write-up about the development of this library at http://hackaday.io/Xark (describes most of the optimizations done).
+
+
+Issues
+------
+
+Currently, the library may only be used from the INO file in your project. You _cannot_ include it in a header file and
+use it from other CPP files. The current workaround is to write wrapper functions or classes, declare them in a header
+file, and then implement them in the INO file.


### PR DESCRIPTION
This pull request replaces calls to the non-existent swap() function with calls to swapValue(), defined in PDQ_GFX.h.

Additionally, it includes a warning in the README for a common pitfall: trying to use this library from multiple CPP files in a project.