### PR TITLE
Fixed setting of SPI registers in spi_begin, restructured slightly to support changes

### DIFF
--- a/PDQ_ST7735/examples/PDQ_graphicstest/PDQ_ST7735_config.h
+++ b/PDQ_ST7735/examples/PDQ_graphicstest/PDQ_ST7735_config.h
@@ -47,4 +47,4 @@ enum
 // (other pins used are dictated by AVR HW SPI used as shown above)
 
 // other PDQ library options
-#define	ST7735_SAVE_SPCR	0			// <= 0/1 with 1 to save/restore AVR SPI control register (to "play nice" when other SPI use)
+#define	ST7735_SAVE_SPI_SETTINGS	0			// <= 0/1 with 1 to save AVR SPI control and status registers (required when other SPI devices are in use with other settings)


### PR DESCRIPTION
Enabling `ST7735_SAVE_SPCR` breaks this library (resulting in a white screen). The SPI Status Register contains a [flag for doubling the SPI speed](http://www.avrbeginners.net/architecture/spi/spi.html#spsr) which was not being written like it is by Arduino's `SPI.beginTransaction`.

`spi_begin` and `spi_end` now follow the same structure as their SPI library counterparts. `spi_end` no longer switches back to the old settings (I was still experiencing problems in this scenario, even with the display being the only device used on the bus). `spi_begin` instead copies the values into the registers instead of switching them. While switching them back in `spi_end` would be playing nice for other libraries, other libraries should be using `SPI.beginTransaction` with `SPISettings` or implementing their own system to set the settings before trying to use the SPI.
https://github.com/arduino/ArduinoCore-avr/blob/master/libraries/SPI/src/SPI.h#L203

Finally, the `#define` for enabling this setting writing behaviour is renamed to `ST7735_SAVE_SPI_SETTINGS`, a compiler warning is emitted for the old one (`ST7735_SAVE_SPCR`) and sets `ST7735_SAVE_SPI_SETTINGS` for you. Turning this off is acceptable when there is no other other SPI device use and you want that extra little bit of speed.